### PR TITLE
fix accidental path split

### DIFF
--- a/setup-hook.nix
+++ b/setup-hook.nix
@@ -61,11 +61,11 @@ makeSetupHook
           ${
             if drv.passthru.mutableInstall then
               ''
-                cp -Lr ${drv} ${dest}
-                chmod -R +w ${dest}
+                cp -Lr "${drv}" "${dest}"
+                chmod -R +w "${dest}"
               ''
             else
-              ''ln -s ${drv} ${dest}''
+              ''ln -s "${drv}" "${dest}"''
           }
         ''
       ) finalDeps;


### PR DESCRIPTION
Fix that allows libraries with spaces in the name to work with `platformio2nix`.